### PR TITLE
Tidy shell scripting in build.sh and deploy.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,16 @@ To make changes, raise a
 with code changes that updates swagger file. 
 
 Changes can also be previewed locally (own computer) by either passing a swagger file or http(s) url 
-for raw swagger file via PUBLIC_API_SWAGGER_URL envionment variable as follows:
+for raw swagger file via `PUBLIC_API_SWAGGER_SRC` envionment variable as follows:
 
 ```
-PUBLIC_API_SWAGGER_URL=[PATH_TO_LOCAL_FILE OR HTTP_URL_FOR_RAW_SWAGGER_FILE] ./build.sh
+PUBLIC_API_SWAGGER_SRC=[PATH_TO_LOCAL_FILE OR HTTP_URL_FOR_RAW_SWAGGER_FILE] ./build.sh
 ```
 
 *Examples*
 ```
-PUBLIC_API_SWAGGER_URL=https://raw.githubusercontent.com/alphagov/pay-publicapi/master/swagger/swagger.json ./build.sh
-PUBLIC_API_SWAGGER_URL=/home/projects/pay-publicapi/swagger/swagger.json ./build.sh
+PUBLIC_API_SWAGGER_SRC=https://raw.githubusercontent.com/alphagov/pay-publicapi/master/swagger/swagger.json ./build.sh
+PUBLIC_API_SWAGGER_SRC=/home/projects/pay-publicapi/swagger/swagger.json ./build.sh
 ```
 
 You should now be able to view generated API documentation from folder /shins/build/index.html 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eo pipefail
+set -euo pipefail
 
 # Set up term colors
 green='\033[1;32m'
@@ -8,55 +8,47 @@ red='\033[0;31m'
 white='\033[1;37m'
 NC='\033[0m' # No Color
 
+cd "$(dirname "$0")"
+
 # ---- clean up existing directories 
 rm -rf swagger
-rm -rf shins
 
-if ! command -v node > /dev/null; then \
-  echo -e "${red} Nodejs is not available, please install NodeJs (https://nodejs.org) ${NC}"
-  exit 1; \
+if ! command -v node > /dev/null; then
+  echo -e "${red} Nodejs is not available, please install NodeJs (https://nodejs.org) ${NC}" >&2
+  exit 1
 fi
 
-if ! command -v git > /dev/null; then \
-  echo -e "${red} git is not available, please install Git (https://git-scm.com) ${NC}"
-  exit 1; \
+if ! command -v git > /dev/null; then
+  echo -e "${red} git is not available, please install Git (https://git-scm.com) ${NC}" >&2
+  exit 1
 fi
 
 # -- Get shins to build static files --
-git clone https://github.com/alphagov/shins.git
+rm -rf shins && git clone https://github.com/alphagov/shins.git
 
 # -- Get Swagger file --
-if [[ -z "${PUBLIC_API_BRANCH}" ]]; then
-    PUBLIC_API_BRANCH="master"
-else
-    PUBLIC_API_BRANCH="${PUBLIC_API_BRANCH}"
-fi;
+: "${PUBLIC_API_SWAGGER_SRC:=https://raw.githubusercontent.com/alphagov/pay-publicapi/${PUBLIC_API_BRANCH:-master}/swagger/swagger.json}"
 
-if [[ -z "${PUBLIC_API_SWAGGER_URL}" ]]; then
-    PUBLIC_API_SWAGGER_URL="https://raw.githubusercontent.com/alphagov/pay-publicapi/${PUBLIC_API_BRANCH}/swagger/swagger.json"
+echo "Getting Swagger file from location '$PUBLIC_API_SWAGGER_SRC'"
+if [ "${PUBLIC_API_SWAGGER_SRC:0:4}" == http ]; then
+    wget -P swagger "$PUBLIC_API_SWAGGER_SRC"
 else
-    PUBLIC_API_SWAGGER_URL="${PUBLIC_API_SWAGGER_URL}"
-fi;
-
-echo "Getting Swagger file from location '$PUBLIC_API_SWAGGER_URL'"
-if [[ $PUBLIC_API_SWAGGER_URL == http* ]]; then
-    wget -P swagger "$PUBLIC_API_SWAGGER_URL"
-else
-    mkdir swagger
-    cp "$PUBLIC_API_SWAGGER_URL" swagger
-fi;
+    mkdir -p swagger
+    cp "$PUBLIC_API_SWAGGER_SRC" swagger/
+fi
 
 # -- Build docs --
 echo -e "${white} Converting swagger file to shins compatible markdown...${NC}"
 cp source/images/govuk_pay_logo.png shins/source/images/logo.png
-npm install && ./node_modules/widdershins/widdershins.js swagger/swagger.json -o shins/source/index.html.md
+npm install
+./node_modules/widdershins/widdershins.js swagger/swagger.json -o shins/source/index.html.md
 
 echo -e "${white} Building static docs...${NC}"
-cd shins && npm install && node shins.js --minify
+cd shins
+npm install
+node shins.js --minify
 
 # -- Move static files to 'build' folder --
-mkdir -p build/source
-cp index.html build/
-cp -R pub/ build/pub
-cp -R source/* build/source
+mkdir -p build
+cp -R index.html pub source build/
 echo -e "${green}Built pay-api-docs static files...${NC}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-set -eo pipefail
+set -euo pipefail
 
-CF="cf"
-CF_API_URL="api.cloud.service.gov.uk"
-CF_SPACE="sandbox"
-CF_ORG="govuk-pay"
-APP_NAME="govukpay-api-browser"
+CF=cf
+CF_API_URL=api.cloud.service.gov.uk
+CF_SPACE=sandbox
+CF_ORG=govuk-pay
+APP_NAME=govukpay-api-browser
 
 # Set up term colors
 green='\033[1;32m'
@@ -15,9 +15,11 @@ white='\033[1;37m'
 yellow='\033[1;33m'
 NC='\033[0m' # No Color
 
-if ! command -v ${CF} > /dev/null; then \
-  echo -e "${red} ${CF} not installed, please install CloudFoundry CLI...${NC}"
-  exit 1; \
+cd "$(dirname "$0")"
+
+if ! command -v ${CF} > /dev/null; then
+  echo -e "${red} ${CF} not installed, please install CloudFoundry CLI...${NC}" >&2
+  exit 1
 fi
 
 echo -e "${white}Installing virtualenv.${NC}"
@@ -36,15 +38,17 @@ set -x
 echo -e "${green}Got PaaS CF API password...${NC}"
 
 echo -e "${white}Logging into CF...${NC}"
+
 set +x
-${CF} login \
-  -a ${CF_API_URL} \
-  -u "${CF_API_USER}" \
-  -p "${CF_API_PASS}" \
-  -o ${CF_ORG} \
-  -s ${CF_SPACE}
+"$CF" login \
+  -a "$CF_API_URL" \
+  -u "$CF_API_USER" \
+  -p "$CF_API_PASS" \
+  -o "$CF_ORG" \
+  -s "$CF_SPACE"
 set -x
+
 echo -e "${green}Successfully logged into CF...${NC}"
 echo -e "${white}Pushing application to CF...${NC}"
-${CF} push ${APP_NAME}
+"$CF" push "$APP_NAME"
 echo -e "${green}Successful deploy CF...${NC}"


### PR DESCRIPTION
- Use native shell constructs for defaulting values
- Send errors to stderr
- Quote all variable expansions
- Ensure build.sh uses the correct working directory
- Rename PUBLIC_SWAGGER_URL to PUBLIC_SWAGGER_SRC as it isn't always a URL