### PR TITLE
RED-45: Reference base Docker images via digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:10-slim
+# node:10-slim
+FROM node@sha256:5177e5de0e87965ed102f5a84856e31c1434e479dd0d90cf8df21d61284c78f1
 
 WORKDIR /app
 


### PR DESCRIPTION
So that we can have confidence our base images aren't being changed without our
knowledge, reference them by digest instead of tag (as tags are not immutable).

Also, add a comment detailing the tag the digest corresponds to.